### PR TITLE
GJP-51: let mouse wheel event get passed to mapController

### DIFF
--- a/api/src/main/java/org/geomajas/javascript/api/client/map/controller/JsMapController.java
+++ b/api/src/main/java/org/geomajas/javascript/api/client/map/controller/JsMapController.java
@@ -43,6 +43,8 @@ public interface JsMapController extends Exportable {
 
 	void setMouseOverHandler(JsMouseOverHandler mouseOverHandler);
 
+	void setMouseWheelHandler(JsMouseWheelHandler mouseWheelHandler);
+
 	void setDownHandler(JsDownHandler downHandler);
 
 	void setUpHandler(JsUpHandler upHandler);
@@ -65,6 +67,8 @@ public interface JsMapController extends Exportable {
 
 	JsMouseOverHandler getMouseOverHandler();
 
+	JsMouseWheelHandler getMouseWheelHandler();
+
 	JsDownHandler getDownHandler();
 
 	JsUpHandler getUpHandler();
@@ -84,4 +88,5 @@ public interface JsMapController extends Exportable {
 	void setMapPresenter(JsMapPresenter map);
 
 	Coordinate getLocation(HumanInputEvent<?> event, String renderSpace);
+
 }

--- a/api/src/main/java/org/geomajas/javascript/api/client/map/controller/JsMouseWheelHandler.java
+++ b/api/src/main/java/org/geomajas/javascript/api/client/map/controller/JsMouseWheelHandler.java
@@ -1,0 +1,38 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.javascript.api.client.map.controller;
+
+import com.google.gwt.event.dom.client.MouseWheelEvent;
+import org.geomajas.annotation.Api;
+import org.timepedia.exporter.client.Export;
+import org.timepedia.exporter.client.ExportClosure;
+import org.timepedia.exporter.client.Exportable;
+
+/**
+ * JavaScript exportable handler for catching mouse wheel events.
+ *
+ * @author Jan Venstermans
+ * @since 1.0.0
+ */
+@Export
+@ExportClosure
+@Api(allMethods = true)
+public interface JsMouseWheelHandler extends Exportable {
+
+	/**
+	 * Executed when a mouse wheel event occurred.
+	 *
+	 * @param event
+	 *            The mouse wheel event.
+	 */
+	void onMouseWheel(MouseWheelEvent event);
+}

--- a/gwt2/impl/src/main/java/org/geomajas/javascript/gwt2/impl/client/map/JsMapPresenterImpl.java
+++ b/gwt2/impl/src/main/java/org/geomajas/javascript/gwt2/impl/client/map/JsMapPresenterImpl.java
@@ -16,6 +16,7 @@ import com.google.gwt.event.dom.client.HumanInputEvent;
 import com.google.gwt.event.dom.client.MouseMoveEvent;
 import com.google.gwt.event.dom.client.MouseOutEvent;
 import com.google.gwt.event.dom.client.MouseOverEvent;
+import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.geomajas.gwt2.client.GeomajasImpl;
@@ -213,6 +214,7 @@ public final class JsMapPresenterImpl implements JsMapPresenter, Exportable {
 	 * JavaScript to GWT controller wrapper.
 	 *
 	 * @author Pieter De Graef
+	 * @author Jan Venstermans
 	 */
 	private class JsController extends AbstractMapController {
 
@@ -274,6 +276,13 @@ public final class JsMapPresenterImpl implements JsMapPresenter, Exportable {
 		public void onDoubleClick(DoubleClickEvent event) {
 			if (mapController.getDoubleClickHandler() != null) {
 				mapController.getDoubleClickHandler().onDoubleClick(event);
+			}
+		}
+
+		@Override
+		public void onMouseWheel(MouseWheelEvent event) {
+			if (mapController.getMouseWheelHandler() != null) {
+				mapController.getMouseWheelHandler().onMouseWheel(event);
 			}
 		}
 	}

--- a/gwt2/impl/src/main/java/org/geomajas/javascript/gwt2/impl/client/map/controller/JsMapControllerImpl.java
+++ b/gwt2/impl/src/main/java/org/geomajas/javascript/gwt2/impl/client/map/controller/JsMapControllerImpl.java
@@ -24,6 +24,7 @@ import org.geomajas.javascript.api.client.map.controller.JsMapController;
 import org.geomajas.javascript.api.client.map.controller.JsMouseMoveHandler;
 import org.geomajas.javascript.api.client.map.controller.JsMouseOutHandler;
 import org.geomajas.javascript.api.client.map.controller.JsMouseOverHandler;
+import org.geomajas.javascript.api.client.map.controller.JsMouseWheelHandler;
 import org.geomajas.javascript.api.client.map.controller.JsUpHandler;
 import org.geomajas.javascript.gwt2.impl.client.JsGwtImpl;
 import org.timepedia.exporter.client.Export;
@@ -37,6 +38,7 @@ import org.timepedia.exporter.client.Exportable;
  * has 2 extra handlers executed on activation and deactivation of this controller on the map.
  *
  * @author Pieter De Graef
+ * @author Jan Venstermans
  * @since 1.0.0
  */
 @Api
@@ -51,6 +53,8 @@ public class JsMapControllerImpl implements JsMapController, Exportable {
 	private JsMouseOutHandler mouseOutHandler;
 
 	private JsMouseOverHandler mouseOverHandler;
+
+	private JsMouseWheelHandler mouseWheelHandler;
 
 	private JsDownHandler downHandler;
 
@@ -88,6 +92,11 @@ public class JsMapControllerImpl implements JsMapController, Exportable {
 	@Override
 	public void setMouseOverHandler(JsMouseOverHandler mouseOverHandler) {
 		this.mouseOverHandler = mouseOverHandler;
+	}
+
+	@Override
+	public void setMouseWheelHandler(JsMouseWheelHandler mouseWheelHandler) {
+		this.mouseWheelHandler = mouseWheelHandler;
 	}
 
 	@Override
@@ -137,6 +146,11 @@ public class JsMapControllerImpl implements JsMapController, Exportable {
 	@Override
 	public JsMouseOverHandler getMouseOverHandler() {
 		return mouseOverHandler;
+	}
+
+	@Override
+	public JsMouseWheelHandler getMouseWheelHandler() {
+		return mouseWheelHandler;
 	}
 
 	@Override

--- a/gwt2/impl/src/main/java/org/geomajas/javascript/gwt2/impl/client/map/controller/JsMapControllerWrapperImpl.java
+++ b/gwt2/impl/src/main/java/org/geomajas/javascript/gwt2/impl/client/map/controller/JsMapControllerWrapperImpl.java
@@ -18,6 +18,7 @@ import com.google.gwt.event.dom.client.MouseMoveEvent;
 import com.google.gwt.event.dom.client.MouseOutEvent;
 import com.google.gwt.event.dom.client.MouseOverEvent;
 import com.google.gwt.event.dom.client.MouseUpEvent;
+import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.event.dom.client.TouchEndEvent;
 import com.google.gwt.event.dom.client.TouchStartEvent;
 import org.geomajas.geometry.Coordinate;
@@ -32,6 +33,7 @@ import org.geomajas.javascript.api.client.map.controller.JsDragHandler;
 import org.geomajas.javascript.api.client.map.controller.JsMouseMoveHandler;
 import org.geomajas.javascript.api.client.map.controller.JsMouseOutHandler;
 import org.geomajas.javascript.api.client.map.controller.JsMouseOverHandler;
+import org.geomajas.javascript.api.client.map.controller.JsMouseWheelHandler;
 import org.geomajas.javascript.api.client.map.controller.JsUpHandler;
 import org.geomajas.javascript.gwt2.impl.client.JsGwtImpl;
 import org.geomajas.javascript.gwt2.impl.client.map.JsMapPresenterImpl;
@@ -91,6 +93,12 @@ public class JsMapControllerWrapperImpl extends JsMapControllerImpl implements E
 
 			public void onMouseOver(MouseOverEvent event) {
 				mapController.onMouseOver(event);
+			}
+		});
+		setMouseWheelHandler(new JsMouseWheelHandler() {
+			@Override
+			public void onMouseWheel(MouseWheelEvent event) {
+				mapController.onMouseWheel(event);
 			}
 		});
 		setDownHandler(new JsDownHandler() {


### PR DESCRIPTION
Needs vote.

example: http://dev.geomajas.org/geomajas-project-javascript-gwt2-example-GJP-51_wheelEventToMapController/examples/default_controllers.html#

deselect navigation and select navigation again. compare with http://dev.geomajas.org/geomajas-project-javascript-gwt2-example-1.0.0-SNAPSHOT/examples/default_controllers.html#
